### PR TITLE
Adds the password expiry when the user's password is updated

### DIFF
--- a/src/Concerns/HasPasswordExpiry.php
+++ b/src/Concerns/HasPasswordExpiry.php
@@ -26,5 +26,14 @@ trait HasPasswordExpiry
                 $model->save();
             }
         });
+
+        static::updating(function ($model) {
+            if (
+                $model->isDirty(config('password-expiry.password_column_name')) &&
+                filled($model->{config('password-expiry.password_column_name')})
+            ) {
+                $model->{config('password-expiry.column_name')} = now()->addDays(config('password-expiry.expires_in'));
+            }
+        });
     }
 }


### PR DESCRIPTION
When updating the user's password through pages other than the package's, the password expiry column doesn't update. This PR adds code to do that.