### PR TITLE
fix: password expiry not being set on model creation

### DIFF
--- a/src/Concerns/HasPasswordExpiry.php
+++ b/src/Concerns/HasPasswordExpiry.php
@@ -17,13 +17,11 @@ trait HasPasswordExpiry
             ]));
         }
 
-        static::created(function ($model) {
-            if(
-                $model->wasChanged(config('password-expiry.password_column_name')) &&
+        static::creating(function ($model) {
+            if (
                 filled($model->{config('password-expiry.password_column_name')})
             ) {
                 $model->{config('password-expiry.column_name')} = now()->addDays(config('password-expiry.expires_in'));
-                $model->save();
             }
         });
 


### PR DESCRIPTION
I've noticed that the password expiry was not being set on model creation. Upon investigating, i found that one of the checks done prior to setting the expiry date where returning false:

```PHP
static::created(function ($model) {
            if (
                $model->wasChanged(config('password-expiry.password_column_name')) && // <- this one
                filled($model->{config('password-expiry.password_column_name')})
            ) {
                $model->{config('password-expiry.column_name')} = now()->addDays(config('password-expiry.expires_in'));
                $model->save();
            }
        });
```

The reason being that `wasChanged()` will evaluate if the field was updated since the last time the model was saved. Since it hasn't it returns false, which is correct, because the user didn't exist before.

I modified the code to skip this check and also changed the event we are listening to to be `creating`, so we're not making another SQL query to set the field - yay!

I wrote a few tests and they are all passing. Please let me know if i'm missing something.

TY! 🚀