### PR TITLE
ensure new password is different from the current password

### DIFF
--- a/resources/lang/en/password-expiry.php
+++ b/resources/lang/en/password-expiry.php
@@ -34,6 +34,10 @@ return [
             'password_reset' => [
                 'success' => 'Password Reset Successful',
             ],
+            'same_password' => [
+                'title' => 'Same Password',
+                'body' => 'The new password must be different from the current password.',
+            ],
         ],
         'exceptions' => [
             'column_not_found' => 'Either the column ":column_name" or the password column ":password_column_name" was not found in the ":table_name" table. Please publish migrations and run them, if the error still persists, publish the config file and update the table_name, column_name, and password_column_name values.',

--- a/src/Pages/ResetPassword.php
+++ b/src/Pages/ResetPassword.php
@@ -133,6 +133,16 @@ class ResetPassword extends SimplePage
             return null;
         }
 
+        // check if new password is different from the current password
+        if (Hash::check($data['password'], $authObject->{config('password-expiry.password_column_name')})) {
+            Notification::make()
+                ->title(__('password-expiry::password-expiry.reset-password.notifications.same_password.title'))
+                ->body(__('password-expiry::password-expiry.reset-password.notifications.same_password.body'))
+                ->danger()
+                ->send();
+            return null;
+        }
+
         // check if both required columns exist in the database
         if (!Schema::hasColumn(config('password-expiry.table_name'), config('password-expiry.column_name'))) {
             Notification::make()


### PR DESCRIPTION
Currently the plugin doesn't check if the new password is different from the current password, which defeats the purpose of demanding that users reset their password after it expires. I've added a validation to do just that, that will prevent the same password to be set and show a notification to the user regarding this rule. I've also added the appropriated messages to the `lang\en\password-expiry.php` file.

I hope you find this helpful! TY! 🚀