### PR TITLE
Change password after first login

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,12 @@ return [
      * There is a bug in laravel where when you change password, the user is redirected to the login page by default. This override 
      * fixes that bug by defining a login route that redirects to your panel's login page.
      */
-    'override_login_route' => true
+    'override_login_route' => true,
+
+    /**
+     * Change password after first login
+     */
+    'change_password_first_login' => false,
 ];
 ```
 

--- a/config/password-expiry.php
+++ b/config/password-expiry.php
@@ -91,5 +91,10 @@ return [
      * There is a bug in laravel where when you change password, the user is redirected to the login page by default. This override 
      * fixes that bug by defining a login route that redirects to your panel's login page.
      */
-    'override_login_route' => true
+    'override_login_route' => true,
+
+    /**
+     * Change password after first login
+     */
+    'change_password_first_login' => false,
 ];

--- a/src/Concerns/HasPasswordExpiry.php
+++ b/src/Concerns/HasPasswordExpiry.php
@@ -19,7 +19,8 @@ trait HasPasswordExpiry
 
         static::creating(function ($model) {
             if (
-                filled($model->{config('password-expiry.password_column_name')})
+                filled($model->{config('password-expiry.password_column_name')}) &&
+                !config('password-expiry.change_password_first_login')
             ) {
                 $model->{config('password-expiry.column_name')} = now()->addDays(config('password-expiry.expires_in'));
             }


### PR DESCRIPTION
Added new config:

`'change_password_first_login' => false`

to force new users setting a new password on their first login.